### PR TITLE
carol.js 2

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,6 +1,6 @@
-# Function: carol
+# Function: token
 ```
-carol(source: string | RegExp): Pattern
+token(source: string | RegExp): Pattern
 ```
 Creates a new pattern from a RegExp or regex string.
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -2,15 +2,15 @@
 
 ## New carol pattern
 ```js
-import carol from 'carol-js';
-const pattern1 = carol(/[a-z]/);
-const pattern2 = carol('[a-z]');
+import C from 'carol-js';
+const pattern1 = C.token(/[a-z]/);
+const pattern2 = C.token('[a-z]');
 ```
 
 ## Convert to a Regex
 ```js
-import carol from 'carol-js';
-const regex = carol(/[a-z]/).toRegex();
+import C from 'carol-js';
+const regex = C.token(/[a-z]/).toRegex();
 ```
 Equals to
 ```js
@@ -19,76 +19,76 @@ const regex = /[a-z]/;
 
 ## Sequence pattern
 ```js
-import carol from 'carol-js';
-carol.seq([
-  carol(/[a-z]/),
-  carol(/[0-9]/),
+import C from 'carol-js';
+C.seq([
+  C.token(/[a-z]/),
+  C.token(/[0-9]/),
 ]);
 // [a-z][0-9]
 ```
 
 ## Match any of the patterns
 ```js
-import carol from 'carol-js';
-carol.alt([
-  carol(/true/),
-  carol(/false/),
+import C from 'carol-js';
+C.alt([
+  C.token(/true/),
+  C.token(/false/),
 ]);
 // (?:true|false)
 ```
 
 ## Repeat pattern
 ```js
-import carol from 'carol-js';
-carol(/[a-z]/).many();
+import C from 'carol-js';
+C.token(/[a-z]/).many();
 // (?:[a-z])*
 
-carol(/[a-z]/).many(1);
+C.token(/[a-z]/).many(1);
 // (?:[a-z])+
 
-carol(/[a-z]/).many(2);
+C.token(/[a-z]/).many(2);
 // (?:[a-z]){2,}
 
-carol(/[a-z]/).many(2, 4);
+C.token(/[a-z]/).many(2, 4);
 // (?:[a-z]){2,4}
 
-carol(/[a-z]/).many({ length: 2 });
+C.token(/[a-z]/).many({ length: 2 });
 // (?:[a-z]){2}
 
-carol(/[a-z]/).many({ min: 2, greedy: false });
+C.token(/[a-z]/).many({ min: 2, greedy: false });
 // (?:[a-z]){2,}?
 
-carol(/[a-z]/).many({ min: 2, max: 4, greedy: false });
+C.token(/[a-z]/).many({ min: 2, max: 4, greedy: false });
 // (?:[a-z]){2,4}?
 ```
 
 ## Optional pattern
 ```js
-import carol from 'carol-js';
-carol(/[a-z]/).option();
+import C from 'carol-js';
+C.token(/[a-z]/).option();
 // (?:[a-z])?
 ```
 
 ## Capture input string
 ```js
-import carol from 'carol-js';
-carol.seq([
-  carol(/[a-z]+/),
-  carol(/-/),
-  carol(/[0-9]+/).capture(),
+import C from 'carol-js';
+C.seq([
+  C.token(/[a-z]+/),
+  C.token(/-/),
+  C.token(/[0-9]+/).capture(),
 ]);
 // [a-z]+-([0-9]+)
 ```
 
 ## Exact match
 ```js
-import carol from 'carol-js';
-carol(/[a-z]/).toRegex({ exact: true });
+import C from 'carol-js';
+C.token(/[a-z]/).toRegex({ exact: true });
 // ^[a-z]$
 ```
 
 ## Case insensitive match
 ```js
-import carol from 'carol-js';
-carol(/[a-z]/).toRegex({ flags: "i" });
+import C from 'carol-js';
+C.token(/[a-z]/).toRegex({ flags: "i" });
 ```

--- a/examples/helloworld/index.js
+++ b/examples/helloworld/index.js
@@ -1,11 +1,11 @@
-import carol from 'carol-js';
+import C from 'carol-js';
 import assert from 'node:assert';
 
-const helloworld = carol.seq([
-  carol(/hello/),
-  carol(/ /),
-  carol(/world/),
-  carol(/!/).many(1),
+const helloworld = C.seq([
+  C.token(/hello/),
+  C.token(/ /),
+  C.token(/world/),
+  C.token(/!/).many(1),
 ]).many();
 
 const regex = helloworld.toRegex({ exact: true });

--- a/examples/uuid/index.js
+++ b/examples/uuid/index.js
@@ -1,16 +1,16 @@
-import carol from 'carol-js';
+import C from 'carol-js';
 import assert from 'node:assert';
 
-const hex = carol(/[0-9a-f][0-9a-f]/);
-const uuid = carol.seq([
+const hex = C.token(/[0-9a-f][0-9a-f]/);
+const uuid = C.seq([
   hex.many({ length: 4 }),
-  carol(/-/),
+  C.token(/-/),
   hex.many({ length: 2 }),
-  carol(/-/),
+  C.token(/-/),
   hex.many({ length: 2 }),
-  carol(/-/),
+  C.token(/-/),
   hex.many({ length: 2 }),
-  carol(/-/),
+  C.token(/-/),
   hex.many({ length: 6 }),
 ]);
 const regex = uuid.toRegex({ flags: "i", exact: true });

--- a/package.dist.json
+++ b/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "carol-js",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A powerful, small tool for building regular expressions.",
   "author": "marihachi <marihachi0620@gmail.com>",
   "repository": {
@@ -12,10 +12,12 @@
   },
   "license": "MIT",
   "keywords": [
+    "utility",
+    "builder",
+    "tools",
     "regex",
     "regular-expression",
-    "utility",
-    "builder"
+    "esm"
   ],
   "type": "module",
   "module": "./carol.js",

--- a/src/carol.ts
+++ b/src/carol.ts
@@ -15,8 +15,8 @@ export type Flag = 'g' | 'i' | 'd' | 'm' | 's' | 'u' | 'y';
 /**
  * Creates a new pattern from a RegExp or regex string.
 */
-function carol(source: string | RegExp): Pattern
-function carol(source: any) {
+function token(source: string | RegExp): Pattern
+function token(source: any) {
   var patternSource;
   if (typeof source === 'string') {
     patternSource = source;
@@ -217,14 +217,16 @@ class Pattern {
   }
 }
 
+var carol = {
+  token,
+  seq,
+  alt,
+  Pattern,
+};
 export default carol;
-carol.carol = carol;
-carol.seq = seq;
-carol.alt = alt;
-carol.Pattern = Pattern;
 
 export {
-  carol,
+  token,
   seq,
   alt,
   Pattern,

--- a/test/api.ts
+++ b/test/api.ts
@@ -1,10 +1,10 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
-import _default, { carol, Pattern, alt, seq } from '../dist/carol.js';
+import _default, { token, Pattern, alt, seq } from '../dist/carol.js';
 
 describe('api', () => {
   test('carol', () => {
-    assert.strictEqual(carol(/abc/).source, 'abc');
+    assert.strictEqual(token(/abc/).source, 'abc');
   });
 
   test('Pattern', () => {
@@ -12,41 +12,37 @@ describe('api', () => {
   });
 
   test('seq', () => {
-    assert.strictEqual(seq([carol(/abc/), carol(/xyz/)]).source, 'abcxyz');
+    assert.strictEqual(seq([token(/abc/), token(/xyz/)]).source, 'abcxyz');
   });
 
   test('alt', () => {
-    assert.strictEqual(alt([carol(/abc/), carol(/xyz/)]).source, '(?:abc|xyz)');
+    assert.strictEqual(alt([token(/abc/), token(/xyz/)]).source, '(?:abc|xyz)');
   });
 
   test('Pattern.many', () => {
-    const p = carol(/abc/);
+    const p = token(/abc/);
     assert.strictEqual(p.many().source, '(?:abc)*');
   });
 
   test('Pattern.option', () => {
-    const p = carol(/abc/);
+    const p = token(/abc/);
     assert.strictEqual(p.option().source, '(?:abc)?');
   });
 
   test('Pattern.capture', () => {
-    const p = carol(/abc/);
+    const p = token(/abc/);
     assert.strictEqual(p.capture().source, '(abc)');
   });
 
   test('Pattern.toRegex', () => {
-    const p = carol(/abc/);
+    const p = token(/abc/);
     assert.ok(p.toRegex() instanceof RegExp);
   });
 });
 
 describe('api (default export)', () => {
-  test('default', () => {
-    assert.strictEqual(_default(/abc/).source, 'abc');
-  });
-
   test('default.carol', () => {
-    assert.strictEqual(_default.carol(/abc/).source, 'abc');
+    assert.strictEqual(_default.token(/abc/).source, 'abc');
   });
 
   test('default.Pattern', () => {
@@ -54,10 +50,10 @@ describe('api (default export)', () => {
   });
 
   test('default.seq', () => {
-    assert.strictEqual(_default.seq([_default.carol(/abc/), _default.carol(/xyz/)]).source, 'abcxyz');
+    assert.strictEqual(_default.seq([_default.token(/abc/), _default.token(/xyz/)]).source, 'abcxyz');
   });
 
   test('default.alt', () => {
-    assert.strictEqual(_default.alt([_default.carol(/abc/), _default.carol(/xyz/)]).source, '(?:abc|xyz)');
+    assert.strictEqual(_default.alt([_default.token(/abc/), _default.token(/xyz/)]).source, '(?:abc|xyz)');
   });
 });

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,76 +1,76 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
-import carol from '../dist/carol.js';
+import C from '../dist/carol.js';
 
 describe('main', () => {
   test('carol()', () => {
-    assert.strictEqual(carol(/abc/).toRegex().source, 'abc');
-    assert.strictEqual(carol('abc').toRegex().source, 'abc');
+    assert.strictEqual(C.token(/abc/).toRegex().source, 'abc');
+    assert.strictEqual(C.token('abc').toRegex().source, 'abc');
   });
 
   test('seq()', () => {
-    assert.strictEqual(carol.seq([carol(/abc/), carol(/xyz/)]).toRegex().source, 'abcxyz');
-    assert.strictEqual(carol.seq([carol(/abc/).many(), carol(/xyz/)]).toRegex().source, '(?:abc)*xyz');
+    assert.strictEqual(C.seq([C.token(/abc/), C.token(/xyz/)]).toRegex().source, 'abcxyz');
+    assert.strictEqual(C.seq([C.token(/abc/).many(), C.token(/xyz/)]).toRegex().source, '(?:abc)*xyz');
   });
 
   test('alt()', () => {
-    assert.strictEqual(carol.alt([carol(/abc/), carol(/xyz/)]).toRegex().source, '(?:abc|xyz)');
+    assert.strictEqual(C.alt([C.token(/abc/), C.token(/xyz/)]).toRegex().source, '(?:abc|xyz)');
   });
 
   test('Pattern.many()', () => {
-    assert.strictEqual(carol(/abc/).many().toRegex().source, '(?:abc)*');
-    assert.strictEqual(carol(/abc/).many(0).toRegex().source, '(?:abc)*');
-    assert.strictEqual(carol(/abc/).many(1).toRegex().source, '(?:abc)+');
-    assert.strictEqual(carol(/abc/).many(2).toRegex().source, '(?:abc){2,}');
-    assert.strictEqual(carol(/abc/).many(3, 5).toRegex().source, '(?:abc){3,5}');
-    assert.strictEqual(carol(/abc/).many({length: 2}).toRegex().source, '(?:abc){2}');
-    assert.strictEqual(carol(/abc/).many(2, 2).toRegex().source, '(?:abc){2}');
+    assert.strictEqual(C.token(/abc/).many().toRegex().source, '(?:abc)*');
+    assert.strictEqual(C.token(/abc/).many(0).toRegex().source, '(?:abc)*');
+    assert.strictEqual(C.token(/abc/).many(1).toRegex().source, '(?:abc)+');
+    assert.strictEqual(C.token(/abc/).many(2).toRegex().source, '(?:abc){2,}');
+    assert.strictEqual(C.token(/abc/).many(3, 5).toRegex().source, '(?:abc){3,5}');
+    assert.strictEqual(C.token(/abc/).many({length: 2}).toRegex().source, '(?:abc){2}');
+    assert.strictEqual(C.token(/abc/).many(2, 2).toRegex().source, '(?:abc){2}');
   });
 
   test('Pattern.many() greedy', () => {
-    assert.strictEqual(carol(/abc/).many({min: 0, greedy: true}).toRegex().source, '(?:abc)*');
-    assert.strictEqual(carol(/abc/).many({min: 1, greedy: true}).toRegex().source, '(?:abc)+');
-    assert.strictEqual(carol(/abc/).many({min: 2, greedy: true}).toRegex().source, '(?:abc){2,}');
-    assert.strictEqual(carol(/abc/).many({min: 3, max: 5, greedy: true}).toRegex().source, '(?:abc){3,5}');
-    assert.strictEqual(carol(/abc/).many({length: 2, greedy: true}).toRegex().source, '(?:abc){2}');
-    assert.strictEqual(carol(/abc/).many({min: 2, max: 2, greedy: true}).toRegex().source, '(?:abc){2}');
+    assert.strictEqual(C.token(/abc/).many({min: 0, greedy: true}).toRegex().source, '(?:abc)*');
+    assert.strictEqual(C.token(/abc/).many({min: 1, greedy: true}).toRegex().source, '(?:abc)+');
+    assert.strictEqual(C.token(/abc/).many({min: 2, greedy: true}).toRegex().source, '(?:abc){2,}');
+    assert.strictEqual(C.token(/abc/).many({min: 3, max: 5, greedy: true}).toRegex().source, '(?:abc){3,5}');
+    assert.strictEqual(C.token(/abc/).many({length: 2, greedy: true}).toRegex().source, '(?:abc){2}');
+    assert.strictEqual(C.token(/abc/).many({min: 2, max: 2, greedy: true}).toRegex().source, '(?:abc){2}');
 
-    assert.strictEqual(carol(/abc/).many({min: 0, greedy: false}).toRegex().source, '(?:abc)*?');
-    assert.strictEqual(carol(/abc/).many({min: 1, greedy: false}).toRegex().source, '(?:abc)+?');
-    assert.strictEqual(carol(/abc/).many({min: 2, greedy: false}).toRegex().source, '(?:abc){2,}?');
-    assert.strictEqual(carol(/abc/).many({min: 3, max: 5, greedy: false}).toRegex().source, '(?:abc){3,5}?');
-    assert.strictEqual(carol(/abc/).many({length: 2, greedy: false}).toRegex().source, '(?:abc){2}?');
-    assert.strictEqual(carol(/abc/).many({min: 2, max: 2, greedy: false}).toRegex().source, '(?:abc){2}?');
+    assert.strictEqual(C.token(/abc/).many({min: 0, greedy: false}).toRegex().source, '(?:abc)*?');
+    assert.strictEqual(C.token(/abc/).many({min: 1, greedy: false}).toRegex().source, '(?:abc)+?');
+    assert.strictEqual(C.token(/abc/).many({min: 2, greedy: false}).toRegex().source, '(?:abc){2,}?');
+    assert.strictEqual(C.token(/abc/).many({min: 3, max: 5, greedy: false}).toRegex().source, '(?:abc){3,5}?');
+    assert.strictEqual(C.token(/abc/).many({length: 2, greedy: false}).toRegex().source, '(?:abc){2}?');
+    assert.strictEqual(C.token(/abc/).many({min: 2, max: 2, greedy: false}).toRegex().source, '(?:abc){2}?');
   });
 
   test('Pattern.many() simple char', () => {
-    assert.strictEqual(carol(/a/).many().toRegex().source, 'a*');
-    assert.strictEqual(carol(/a/).many(1).toRegex().source, 'a+');
+    assert.strictEqual(C.token(/a/).many().toRegex().source, 'a*');
+    assert.strictEqual(C.token(/a/).many(1).toRegex().source, 'a+');
   });
 
   test('Pattern.option()', () => {
-    assert.strictEqual(carol(/abc/).option().toRegex().source, '(?:abc)?');
+    assert.strictEqual(C.token(/abc/).option().toRegex().source, '(?:abc)?');
   });
 
   test('Pattern.option() greedy', () => {
-    assert.strictEqual(carol(/abc/).option({greedy: true}).toRegex().source, '(?:abc)?');
-    assert.strictEqual(carol(/abc/).option({greedy: false}).toRegex().source, '(?:abc)??');
+    assert.strictEqual(C.token(/abc/).option({greedy: true}).toRegex().source, '(?:abc)?');
+    assert.strictEqual(C.token(/abc/).option({greedy: false}).toRegex().source, '(?:abc)??');
   });
 
   test('Pattern.option() simple char', () => {
-    assert.strictEqual(carol(/a/).option().toRegex().source, 'a?');
+    assert.strictEqual(C.token(/a/).option().toRegex().source, 'a?');
   });
 
   test('Pattern.capture()', () => {
-    assert.strictEqual(carol(/abc/).capture().toRegex().source, '(abc)');
+    assert.strictEqual(C.token(/abc/).capture().toRegex().source, '(abc)');
   });
 
   test('hello world', () => {
-    const regex = carol.seq([
-      carol(/hello/),
-      carol(/ /),
-      carol(/world/),
-      carol(/!/).many(1),
+    const regex = C.seq([
+      C.token(/hello/),
+      C.token(/ /),
+      C.token(/world/),
+      C.token(/!/).many(1),
     ]).many().toRegex();
 
     assert.strictEqual(regex.source, '(?:hello world(?:!)+)*');


### PR DESCRIPTION
- carol関数に関する変更
  - carolからtokenに名前変更
- default exportでcarol関数を返すのをやめて、通常のオブジェクトにする。
